### PR TITLE
Adds .adoc extension support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // constants
 class Constants {
-    public static readonly adoc: string = ".asciidoc";
+    public static readonly adoc: string = ".{asciidoc,adoc}";
     public static readonly images: string = "images";
     public static readonly image: string = "image::";
     public static readonly localhost: string = "http://localhost";


### PR DESCRIPTION
Addes support for `.adoc` file extension for asciidoc files. [Asciidoctor](https://github.com/asciidoctor/asciidoctor) uses `.adoc` extension.

Test Output:
```bash
npm test

> @oasp/asciidoc-link-checker@1.1.2 test /home/user/asciidoc-link-checker
> mocha --opts mocha.opts



  fixLink function
    ✓ should return true

  getLinkValue function
    ✓ should return https://www.google.es

  getImageValue function
    ✓ should return true true true true

  sendRequest  function
    ✓ should return true (431ms)

  sendRequest  function
 undefined ---> http://dilbert.com/404 ---> 404
    ✓ should return false (575ms)


  5 passing (1s)

```